### PR TITLE
[bugfix] remove extra normalisation

### DIFF
--- a/ccf_streamlines/projection.py
+++ b/ccf_streamlines/projection.py
@@ -949,17 +949,9 @@ class IsocortexCoordinateProjector:
                 if not appended:
                     depth.append(np.nan)
 
-        if thickness_type == "normalized_layers":
-            ref_total_thickness = np.sum(list(self.layer_thicknesses.values()))
-            depth = np.array(depth) / ref_total_thickness * full_thickness_voxels
-        else:
-            depth = np.array(depth)
-
+        depth = np.array(depth)
         if scale == "microns":
-            if thickness_type == "normalized_layers":
-                depth_microns = depth * ref_total_thickness / full_thickness_voxels
-            else:
-                depth_microns = depth * self.resolution[1]
+            depth_microns = depth * self.resolution[1]
             return depth_microns
         else:
             return depth


### PR DESCRIPTION
If thickness_type is `normalized_layers`, a list of layer layer_thicknesses must be provided to the projector and each layer is normalised to have this thickness across the whole cortex. However, depth is rescaled later to have the size of the deepest cortical layer in the volume. This seems confusing as one must know this size to the downscale again to the thicknesses that were provided.
The implementation of the micron seems also buggy as the normalisation happens twice (but I don't use it so I haven't tested).

Remove this extra normalisation to make output fitting user provided layer thicknesses.